### PR TITLE
Add desaturation to recolored icons

### DIFF
--- a/tullaRange/tullaRange.lua
+++ b/tullaRange/tullaRange.lua
@@ -292,6 +292,7 @@ function Addon:SetButtonState(button, state, force)
 
     local r, g, b, a = self:GetColor(state)
 
+    button.icon:SetDesaturated(state ~= 'normal')
     button.icon:SetVertexColor(r, g, b, a)
 end
 


### PR DESCRIPTION
To enhance the aspect of recolored icon, i suggest to add a call to SetDesaturated in the same time the addon recolor the icon. It greatly enhance the icon aspect especially when their unmodified colors are highly mono-chromatic (mosly only one color)

i'll post some comparison screenshot